### PR TITLE
Begin work on new Blog section

### DIFF
--- a/websites/livinggracedianella/src/components/AnchorageHeader.astro
+++ b/websites/livinggracedianella/src/components/AnchorageHeader.astro
@@ -26,6 +26,7 @@ import { HeaderToggle } from "@rkn/base-components";
             />
         </HeaderNavDropdown>
         <HeaderNavItem itemhref="/moorings" itemName="Moorings" />
+        <HeaderNavItem itemhref="/blog" itemName="Blog" />
         <HeaderNavItem itemhref="/contact" itemName="Contact" />
     </HeaderNav>
     <HeaderToggle />

--- a/websites/livinggracedianella/src/components/SinglePostItem.astro
+++ b/websites/livinggracedianella/src/components/SinglePostItem.astro
@@ -1,0 +1,35 @@
+---
+import { formatDistance, format } from 'date-fns';
+import { marked } from 'marked';
+export interface Props {
+  post: object
+}
+
+const { post } = Astro.props;
+const { attributes: { title, summary, date } } = post || {};
+const content = marked.parse(summary);
+---
+<div>
+    <div className="my-4 text-center">
+        <h1 className="text-center text-4xl leading-tight text-gray-900 my-4 font-bold">{title}</h1>
+        <div className="text-gray-500 flex justify-center items-center space-x-2">
+            <span>&middot;</span>
+            <span>{format(new Date(date), 'MM/dd/yyyy')}</span>
+            <span>&middot;</span>
+            <span>{/*readingTime*/}</span>
+        </div>
+    </div>
+    <div className="rounded-md h-56 w-full overflow-hidden">
+        <img
+            className="object-cover w-full h-full"
+            src={
+                // featuredImage
+                //    ? `http://localhost:1337${featuredImage.url}`
+                //    : 'https://via.placeholder.com/1080'
+                'https://via.placeholder.com/180'
+            }
+        />
+    </div>
+    <article set:html={content} className="prose max-w-full w-full my-4">
+    </article>
+</div>

--- a/websites/livinggracedianella/src/pages/blog.astro
+++ b/websites/livinggracedianella/src/pages/blog.astro
@@ -1,0 +1,20 @@
+---
+import AnchorageBaseLayout from "../layouts/AnchorageBaseLayout.astro";
+import { HeroBannerShallow } from "@rkn/page-components";
+import EventGrid from "../components/EventGrid.astro";
+
+const  { data: posts } =  await fetch(`http://192.168.1.102:1337/api/posts`).then(res => res.json())
+const title = "Blog";
+---
+
+<AnchorageBaseLayout title={title}>
+    <HeroBannerShallow
+        BackgroundImage="images/HeaderImage.jpg"
+        HeroText="Blog."
+    />
+    <div class="container">
+        <h2>Blog</h2>
+        <p><em>Thoughtful musings from thoughtful people</em></p>
+    </div>
+    <EventGrid events={posts}/>
+</AnchorageBaseLayout>

--- a/websites/livinggracedianella/src/pages/event/[slug].astro
+++ b/websites/livinggracedianella/src/pages/event/[slug].astro
@@ -4,12 +4,12 @@ import Layout from '../../layouts/Layout.astro';
 import SingleEventItem from "../../components/SingleEventItem.astro"
 
 export async function getStaticPaths() {
-  const  { data: events } =  await fetch(`http://pro.local:1337/api/events?populate[organisers][populate][0]=Portrait`).then(res => res.json())
+  const  { data: events } =  await fetch(`http://192.168.1.102:1337/api/events?populate[organisers][populate][0]=Portrait`).then(res => res.json())
   return  events.map(event =>  ({params : {slug: event.attributes.slug}}))
 }
 
 const {slug} =  Astro.params
-const { data: eventItem } = await fetch(`http://pro.local:1337/api/events?populate[organisers][populate][0]=Portrait&slug=${slug}`).then(x  => x.json())
+const { data: eventItem } = await fetch(`http://192.168.1.102:1337/api/events?populate[organisers][populate][0]=Portrait&slug=${slug}`).then(x  => x.json())
 ---
 
 <Layout title={eventItem[0]?.title}>

--- a/websites/livinggracedianella/src/pages/index.astro
+++ b/websites/livinggracedianella/src/pages/index.astro
@@ -10,7 +10,7 @@ import { HeroImageScroll } from "@rkn/page-components";
 import Layout from '../layouts/Layout.astro';
 import Card from '../components/Card.astro';
 import EventGrid from "../components/EventGrid.astro";
-const  { data: events } = await fetch(`http://pro.local:1337/api/events?populate[organisers][populate][0]=Portrait`).then(res => res.json())
+const  { data: events } = await fetch(`http://192.168.1.102:1337/api/events?populate[organisers][populate][0]=Portrait`).then(res => res.json())
 ---
 
 <AnchorageBaseLayout>

--- a/websites/livinggracedianella/src/pages/post/[slug].astro
+++ b/websites/livinggracedianella/src/pages/post/[slug].astro
@@ -1,0 +1,16 @@
+---
+import BlogLayout from '../../layouts/Layout.astro';
+import SinglePostItem from "../../components/SinglePostItem.astro"
+
+export async function getStaticPaths() {
+  const  { data: posts } =  await fetch(`http://192.168.1.102:1337/api/posts`).then(res => res.json())
+  return posts.map(post =>  ({params : {slug: post.attributes.slug}}))
+}
+
+const {slug} =  Astro.params
+const { data: postItem } = await fetch(`http://192.168.1.102:1337/api/posts?slug=${slug}`).then(x  => x.json())
+---
+
+<BlogLayout title={postItem[0]?.title}>
+  <SinglePostItem post={postItem[0]}/>
+</BlogLayout>


### PR DESCRIPTION
The LGD site now has a blog section, based on the one from the Anchorage site. It currently reuses parts of the EventGrid components that display events. It currently has a bug where the EventGridItems that display blog Cards on the Blog index page have their links incorrectly pointing to /events. (This is because the EventGridItem that contains the Card component is a little too specifically set up for events. It could be made more generic).

TODO:
- Fix the above bug so that EventGrids and EventGridItems items are built as a more generic 'Grid' and 'GridItem', or Grids allow multiple types of item (eg events, or posts) directly)?
- Properly style the SinglePostItem pages.
- Update the headers and styling etc so that the things specific to The Anchorage are changed or removed.
- Fix the hardcoded local ip addresses that are used to point to the CMS API